### PR TITLE
Review timezone handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 Script to set geotag to photo from gpx file
 
-Syntax: ./geotag_photos.py [-g|--gpx] file.gpx [[-t|--timediff] -02] file1.jpg [file2.jpg ... ] 
+## Usage
 
-For timezome "Europe/Rome" in summer is timedelta +2, in winter +1.
+```
+geotag_photos.py [-h] -g GPX [-z TIMEZONE] IMAGE [IMAGE ...]
 
+positional arguments:
+  IMAGE                 Image file to geotag
+
+options:
+  -h, --help            show this help message and exit
+  -g GPX, --gpx GPX     File GPX to match photos to
+  -z TIMEZONE, --timezone TIMEZONE
+                        Force timezone on photos creation datetime. Must be a valid IANA timezone identifier, e.g.
+                        'Europe/Paris', or an offset '+02:00'. If not set, timezone from gpx track is used.
+```

--- a/pyexif.py.patch
+++ b/pyexif.py.patch
@@ -1,0 +1,6 @@
+# venv/lib/python3.12/site-packages/pyexif/pyexif.py
+36c36,37
+<             if stderr.startswith("Warning: Bad ExifIFD directory") and fpath is not None and retry:
+---
+>             if (stderr.startswith("Warning: Bad ExifIFD directory") or "Error reading OtherImageStart data in IFD0" in stderr) \
+>                     and fpath is not None and retry:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 gpxpy==1.5.0
 pyexif==1.0.0
-pytz==2023.3.post1


### PR DESCRIPTION
Force timezone on datetime parsed from exif.
If user don't specify any timezone, we use timezone from first point in
gps track, or we fallback to system timezone.

Replace pytz with zoneinfo from standard lib.
Requires python >=3.9

Also update README with usage from help